### PR TITLE
feat(feeds): can directly subscribe to some youtube feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 24.09.3
+
+- Can subscribe with channel or playlist link.
+  - For channels, it must be a link of the form `/channel/<CHANNEL_ID>`. The clean url with `/@ChannelName` doesn’t work.
+
 ## 24.09.2
 
 - Improve logging for `clean_data`

--- a/legadilo/feeds/views/subscribe_to_feed_view.py
+++ b/legadilo/feeds/views/subscribe_to_feed_view.py
@@ -49,6 +49,7 @@ from ..services.feed_parsing import (
 
 class SubscribeToFeedForm(forms.Form):
     url = forms.URLField(
+        max_length=2048,
         assume_scheme="https",
         help_text=_(
             "Enter the URL to the feed you want to subscribe to or of a site in which case we will "

--- a/legadilo/reading/views/fetch_article_views.py
+++ b/legadilo/reading/views/fetch_article_views.py
@@ -44,6 +44,7 @@ from legadilo.utils.urls import add_query_params, pop_query_param, validate_refe
 
 class FetchArticleForm(forms.Form):
     url = forms.URLField(
+        max_length=2048,
         assume_scheme="https",
         help_text=_("URL of the article to add."),
     )


### PR DESCRIPTION
If we pass a channel or a playlist URL, we can subscribe to the feed automatically.

For all other URLs, we are still stuck and can’t subscribe to anything.

Close #148